### PR TITLE
speed up calculating of longest streaks

### DIFF
--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -34,7 +34,7 @@ class Match < ActiveRecord::Base
   end
 
   def win_for?(user)
-    winner_team.users.map(&:id).include?(user.id)
+    winner_team.user_ids.include?(user.id)
   end
 
   def winner_team?(team)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -80,6 +80,10 @@ class Team < ActiveRecord::Base
     [player1, player2].compact
   end
 
+  def user_ids
+    [player1_id, player2_id]
+  end
+
   def double?
     self.users.size > 1
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,3 @@
-require 'benchmark'
 class User < ActiveRecord::Base
 
   belongs_to :league

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+require 'benchmark'
 class User < ActiveRecord::Base
 
   belongs_to :league
@@ -98,7 +99,7 @@ class User < ActiveRecord::Base
   end
 
   def calculate_longest_streak!
-    matches = self.matches
+    matches = self.matches.includes(:winner_team, :loser_team)
     current_winning_streak = 0
     matches.each do |match|
       if match.win_for?(self)


### PR DESCRIPTION
Well, I guess this is a first step in the right direction.

Before:
`=> #<Benchmark::Tms:0x007fe988e6c390 @label="", @real=2.984086545999162, @cstime=0.0, @cutime=0.0, @stime=0.24, @utime=2.0199999999999996, @total=2.26>`

After:
`=> #<Benchmark::Tms:0x007f82049b6b20 @label="", @real=0.0729897640121635, @cstime=0.0, @cutime=0.0, @stime=0.0, @utime=0.05999999999999961, @total=0.05999999999999961>`
