### PR TITLE
Refactor the way the current streak is calculated

### DIFF
--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -21,6 +21,8 @@ class Match < ActiveRecord::Base
     joins('LEFT JOIN teams ON (matches.winner_team_id = teams.id OR matches.loser_team_id = teams.id)')
     .where('teams.player1_id = :id OR teams.player2_id = :id', id: id)
   }
+  scope :lost_by, -> id { joins(:loser_team).where('teams.player1_id = :id OR teams.player2_id = :id', id: id) }
+  scope :won_by, -> id { joins(:winner_team).where('teams.player1_id = :id OR teams.player2_id = :id', id: id) }
 
   after_commit :publish_created_notification, on: :create
   after_commit :publish_updated_notification, on: :update

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,8 +85,6 @@ class User < ActiveRecord::Base
       scope = scope.where('date > ?', date_of_last_lost_match.date)
     end
     scope.count
-  rescue NoMethodError => ex
-    0
   end
 
   def calculate_current_streak!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -80,15 +80,13 @@ class User < ActiveRecord::Base
   end
 
   def current_streak
-    wins = []
-    matches.each do |m|
-      if m.win_for?(self)
-        wins << m
-      else
-        break
-      end
+    scope = Match.won_by(id)
+    if date_of_last_lost_match = Match.lost_by(id).select(:date).reorder('date DESC').first
+      scope = scope.where('date > ?', date_of_last_lost_match.date)
     end
-    wins.length
+    scope.count
+  rescue NoMethodError => ex
+    0
   end
 
   def calculate_current_streak!


### PR DESCRIPTION
Instead of fetching all user matches and reversely iterating till a game
was lost, we can simply get the date of the last lost game and count all
won games since. If no game was lost, all games ever played are used.