### PR TITLE
Validate field length for user image, name, and email

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,9 @@ class User < ActiveRecord::Base
 
   scope :ranked, lambda { order("quota DESC") }
 
-  validates :name, presence: true
+  validates :name, presence: true, length: { maximum: 255 }
+  validates :email, length: { maximum: 255 }
+  validates :image, length: { maximum: 255 }
 
   BADGES = %w{ crawling longest_winning most_teams winning_streak last_one crawler }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,6 +4,16 @@ describe User, type: :model do
 
   subject { FactoryGirl.build(:user) }
 
+  describe 'create' do
+    [:name, :image, :email].each do |field|
+      it "handles very long inputs for #{field}" do
+        subject.send("#{field}=", 'a' * 256)
+        expect(subject).to_not be_valid
+        expect(subject.errors[field].length).to eq(1)
+      end
+    end
+  end
+
   describe "scopes" do
     describe "ranked" do
       it "sorts by quota desc" do


### PR DESCRIPTION
As there is a limit of 255 characters, we should ensure that the user
cannot submit data with more than that. Otherwise the insert fails on
database level causing the app to throw an error.