### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# This is an EditorConfig file
+# http://EditorConfig.org
+# It configures your editor or IDE according to the project standards
+
+# top-most EditorConfig file
+root = true
+
+# These rules apply to all files
+[*]
+# Unix-style newlines
+end_of_line = lf
+# Newline at the end of the file (See: https://robots.thoughtbot.com/no-newline-at-end-of-file)
+insert_final_newline = true
+# Set default charset
+charset = utf-8
+# 2 space indentation
+indent_style = space
+indent_size = 2
+# Trim trailing whitespace
+trim_trailing_whitespace = true


### PR DESCRIPTION
.editorconfig specifies generic coding conventions. most improtabtly for us:
spaces instead of tabs, no trailing whitespace, newline at the end of files.

contributors are asked to install the relevant editor plugin - see [http://editorconfig.org/#download](http://editorconfig.org/#download).
