### PR TITLE
Refactor/stats calculation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,10 +27,11 @@ gem "omniauth-twitter"
 gem "omniauth-facebook"
 gem 'rails_admin'
 gem 'pebble_timeline'
-gem 'chameleon', git: 'https://github.com/stephanpavlovic/chameleon.git' #path: '/Users/stephanpavlovic/code/chameleon' 
+gem 'chameleon', git: 'https://github.com/stephanpavlovic/chameleon.git' #path: '/Users/stephanpavlovic/code/chameleon'
 gem 'carrierwave'
 gem 'mini_magick'
 gem 'fog'
+gem 'rubocop'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,9 @@ GEM
       builder
       multi_json
     arel (6.0.3)
+    ast (2.2.0)
+    astrolabe (1.3.1)
+      parser (~> 2.2)
     awesome_print (1.6.1)
     better_errors (2.1.1)
       coderay (>= 1.0.0)
@@ -343,10 +346,13 @@ GEM
     omniauth-twitter (1.2.1)
       json (~> 1.3)
       omniauth-oauth (~> 1.1)
+    parser (2.2.3.0)
+      ast (>= 1.1, < 3.0)
     pebble_timeline (0.0.5)
       faraday
       roar
     pg (0.18.3)
+    powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -423,6 +429,7 @@ GEM
       activesupport (= 4.2.4)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    rainbow (2.0.0)
     rake (10.4.2)
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
@@ -458,6 +465,14 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    rubocop (0.35.1)
+      astrolabe (~> 1.3)
+      parser (>= 2.2.3.0, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      tins (<= 1.6.0)
+    ruby-progressbar (1.7.5)
     ruby_parser (3.7.1)
       sexp_processor (~> 4.1)
     rubyzip (1.1.7)
@@ -496,6 +511,7 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     timecop (0.8.0)
+    tins (1.6.0)
     trollop (2.1.2)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -553,6 +569,7 @@ DEPENDENCIES
   rails_admin
   redcarpet
   rspec-rails
+  rubocop
   sass-rails
   shoulda-matchers
   smurfville

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -14,6 +14,13 @@ class Team < ActiveRecord::Base
 
   scope :ranked, lambda { where('number_of_wins > 1 OR number_of_losses > 1')}
 
+  def update_stats
+    update_attributes(
+      number_of_wins: wins.count,
+      number_of_losses: losses.count
+    )
+  end
+
   def matches
     Match.for_team(self.id)
   end

--- a/spec/controllers/matches_controller_spec.rb
+++ b/spec/controllers/matches_controller_spec.rb
@@ -40,13 +40,17 @@ describe MatchesController, type: :controller do
       expect(user.reload.winning_streak).to eql(1)
       expect(user2.reload.quota).to eql(1192)
     end
+
     it 'changes points if crawling changes' do
       allow(subject).to receive(:current_league).and_return(league)
-      patch :update, { id: match.id, league_id: league.id,  winner_score: '6', loser_score: '2', crawling: true }
-      expect(user.reload.quota).to eql(1213)
-      expect(user.reload.winning_streak).to eql(1)
-      expect(user2.reload.quota).to eql(1187)
+      patch :update, id: match.id, league_id: league.id, winner_score: '6', loser_score: '2', crawling: true
+      user.reload
+      user2.reload
+      expect(user.quota).to eql(1213)
+      expect(user.winning_streak).to eql(1)
+      expect(user2.quota).to eql(1187)
     end
+
     it 'swap teams if winner scored less scores then loser' do
       allow(subject).to receive(:current_league).and_return(league)
       patch :update, { id: match.id, league_id: league.id,  winner_score: '3', loser_score: '6', crawling: false }

--- a/spec/factories/matches.rb
+++ b/spec/factories/matches.rb
@@ -1,10 +1,10 @@
 FactoryGirl.define do
   factory :match do
-    score "6:3"
+    score '6:3'
     crawling false
     date Date.today
     difference 1
-    association :winner_team, :factory => :team
-    association :loser_team, :factory => :team
+    association :winner_team, factory: :team
+    association :loser_team, factory: :team
   end
 end

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -40,59 +40,32 @@ describe Match, type: :model do
     specify { expect(subject.crawling_for_set(crawling: true)).to eq(true) }
   end
 
-  describe ".revert_points" do
+  describe '.revert_points' do
     before do
-      @match = Match.new(difference: 5)
-      @match.winner_team = FactoryGirl.create(:team, number_of_wins: 5)
-      @match.loser_team = FactoryGirl.create(:team, number_of_losses: 5)
-      @match.save
+      @loser_player = FactoryGirl.create(:user)
+      @winner_player = FactoryGirl.create(:user)
+      @winner_team = FactoryGirl.create(:team, number_of_wins: 5, player1: @loser_player)
+      @loser_team = FactoryGirl.create(:team, number_of_losses: 5, player1: @winner_player)
+      @match = Match.create(difference: 5, winner_team: @winner_team, loser_team: @loser_team)
     end
 
     it 'subtracts the difference for the winner team' do
-      @match.winner_team.player1 = FactoryGirl.create(:user)
-      @match.loser_team.player1 = FactoryGirl.create(:user)
-      @match.revert_points
-      expect(@match.winner_team.users.select{|u| u.quota == 1192}.count).to eq(1)
+      @match.reload.destroy
+      expect(@winner_team.player1.reload.quota).to eq(1200)
     end
 
     it 'adds the difference for the loser team' do
-      @match.winner_team.player1 = FactoryGirl.create(:user)
-      @match.loser_team.player1 = FactoryGirl.create(:user)
-      @match.revert_points
-      expect(@match.loser_team.users.select{|u| u.quota == 1208}.count).to eq(1)
+      @match.reload.destroy
+      expect(@loser_team.player1.reload.quota).to eq(1200)
     end
 
-    it "updates the counts for the teams" do
-      @match.loser_team.player1 = FactoryGirl.create(:user)
-      @match.winner_team.player1 = FactoryGirl.create(:user)
-      @match.revert_points
-      expect(@match.winner_team.number_of_wins).to eq(5)
-      expect(@match.loser_team.number_of_losses).to eq(5)
+    it 'updates the counts for the teams' do
+      @match.reload.destroy
+      expect(@winner_team.reload.number_of_wins).to eq(0)
+      expect(@loser_team.reload.number_of_losses).to eq(0)
     end
   end
 
-  describe '.update_team_streaks' do
-    before do
-      @match = Match.new(difference: 5)
-      @match.winner_team = FactoryGirl.create(:team, number_of_wins: 5)
-      @match.loser_team = FactoryGirl.create(:team, number_of_losses: 5)
-      @match.winner_team.player1 = FactoryGirl.create(:user)
-      @match.loser_team.player1 = FactoryGirl.create(:user)
-      @match.save
-    end
-
-    it 'triggers all recalculations on all match users' do
-      allow(@match.winner_team.player1).to receive(:calculate_current_streak!)
-      allow(@match.winner_team.player1).to receive(:calculate_longest_streak!)
-      allow(@match.loser_team.player1).to receive(:calculate_current_streak!)
-      allow(@match.loser_team.player1).to receive(:calculate_longest_streak!)
-      @match.update_team_streaks
-      expect(@match.winner_team.player1).to have_received(:calculate_current_streak!)
-      expect(@match.winner_team.player1).to have_received(:calculate_longest_streak!)
-      expect(@match.loser_team.player1).to have_received(:calculate_current_streak!)
-      expect(@match.loser_team.player1).to have_received(:calculate_longest_streak!)
-    end
-  end
 
   describe ".swap_teams" do
     it "swaps winner and loser team" do


### PR DESCRIPTION
User- & Team-Statistic is updated:
-  whenever a match is created, updated or deleted
- from the total set of matches played by this user 

This prevents errors due to relational calculations. Might impact performance though