### PR TITLE
Perform slug validation before checking for uniqueness

### DIFF
--- a/app/models/league.rb
+++ b/app/models/league.rb
@@ -12,7 +12,7 @@ class League < ActiveRecord::Base
   validates :slug, presence: true, uniqueness: true
   validates :contact_email, presence: true
 
-  before_save :sanitize_slug
+  before_validation :sanitize_slug
 
   scope :by_matches, lambda { order('matches_count DESC') }
 

--- a/spec/models/league_spec.rb
+++ b/spec/models/league_spec.rb
@@ -16,4 +16,11 @@ describe League, type: :model do
     end
   end
 
+  describe 'create' do
+    it 'does not allow duplicated ' do
+      FactoryGirl.create(:league, slug: 'test')
+      expect { FactoryGirl.create(:league, slug: 'Test') }.to raise_error(ActiveRecord::RecordInvalid)
+    end
+  end
+
 end


### PR DESCRIPTION
Performing the uniqueness check before slug is sanitised allows to users to create multiple leagues with the same slug. That’s reaaaallly bad!